### PR TITLE
Fixed "Db7" typo on Ide7 page.

### DIFF
--- a/scrshots/ide7.htm
+++ b/scrshots/ide7.htm
@@ -127,7 +127,7 @@ login.
 
 <div><h3>Usage</h3>
 <p>
-Db7 can be executed from the commandline with:
+Ide7 can be executed from the commandline with:
 </p><pre class="indent">
 s7 ide7
 </pre><p>


### PR DESCRIPTION
Hey! I just stumbled upon your language within the past few days and I have to say that it looks amazing and has a fascinating combination of unusual properties!

Anyway, I noticed a typo on this page and thought I'd tell you about it.

Thanks for creating and making such an interesting language available for everyone! 😎

(PS: I downloaded a bunch of your website's pages manually for offline browsing as reference material, since as a rule I always make sure I can get offline copies when using any less-known language. I noticed that *some* of the documentation is included with the distribution of Seed7 but not all. It'd be nice if there was a way to download *all* the site's info instead of just some or if that was included with the release's folder by default anyway. Having reliable and as-complete-as-possible offline documentation always around is essential for less-known languages I think. There are document generators (e.g. `pandoc`) that *might* be able to help with that (not sure). Anyway though, thanks again! Very cool stuff!)