### PR TITLE
Fixed duplication typo `do do` in early tutorial example code.

### DIFF
--- a/manual/tutorial.htm
+++ b/manual/tutorial.htm
@@ -310,7 +310,7 @@ $ <span class="keywd">include</span> <span class="lib">"seed7_05.s7i"</span>;
   <span class="keywd">local</span>
     <span class="keywd">var</span> <a class="type_no_ul" href="types.htm#integer">integer</a>: count <span class="keywd">is</span> 1;
   <span class="keywd">begin</span>
-    <a class="keywd_no_ul" href="stats.htm#while-statement">while</a> count <a class="op_no_ul" href="../libraries/integer.htm#(in_integer)<=(in_integer)">&lt;=</a> 10 do <a class="keywd_no_ul" href="stats.htm#while-statement">do</a>
+    <a class="keywd_no_ul" href="stats.htm#while-statement">while</a> count <a class="op_no_ul" href="../libraries/integer.htm#(in_integer)<=(in_integer)">&lt;=</a> 10 <a class="keywd_no_ul" href="stats.htm#while-statement">do</a>
       <a class="func_no_ul" href="../libraries/stdio.htm#writeln(in_string)">writeln</a>(count);
       count <a class="op_no_ul" href="stats.htm#Assignment">:=</a> count <a class="op_no_ul" href="../libraries/integer.htm#(in_integer)+(in_integer)">+</a> 1;
     <a class="keywd_no_ul" href="stats.htm#while-statement">end while</a>;


### PR DESCRIPTION
Besides the other typo I noticed today, I also saw that there was an extra `do` in the tutorial that caused that code to break.

Look closely at the following code or try running it:

```
$ include "seed7_05.s7i";

const proc: main is func
  local
    var integer: count is 1;
  begin
    while count <= 10 do do
      writeln(count);
      count := count + 1;
    end while;
  end func;
```

I'm not sure if this HTML was auto-generated though, in which case this correction may also need to be applied somewhere else too (i.e. wherever the HTML is being generated from, if it is).

The typo could confuse or deter newbies, since it is so early in the tutorial.