### PR TITLE
Fixed a few typos in the FAQ "Are there automatic casts to the right type?" section.

### DIFF
--- a/faq.htm
+++ b/faq.htm
@@ -1755,11 +1755,11 @@ const func array array string: test (in string: value) is func
 </h3></a><hr />
 <p>
 Seed7 cannot read the mind of the programmer. It is hard to find out what the
-programmer considers as "right type". A conversion can lose information.
+programmer considers as the "right type". A conversion can lose information.
 Seemingly safe conversions may also lose information. E.g. Not all 64-bit
 integer values can be represented as 64-bit float values. It can also lead to
 unplanned behavior if the programmer is not aware of an automatic conversion.
-Readability is improved if conversions are done explicitly. Seed7 is strong
+Readability is improved if conversions are done explicitly. Seed7 is strongly
 typed and uses explicit conversions. E.g.: The conversion from <tt><a class="type" href="manual/types.htm#integer">integer</a></tt>
 to <tt><a class="type" href="manual/types.htm#float">float</a></tt> is done with the functions <tt><a class="func" href="libraries/float.htm#flt(in_integer)">flt</a></tt> and <tt><a class="func" href="libraries/float.htm#float(in_integer)">float</a></tt>. Conversions from
 <tt><a class="type" href="manual/types.htm#float">float</a></tt> to <tt><a class="type" href="manual/types.htm#integer">integer</a></tt> are done with <tt><a class="func" href="libraries/float.htm#round(in_float)">round</a></tt> or <tt><a class="func" href="libraries/float.htm#trunc(in_float)">trunc</a></tt>. Explicit conversions
@@ -1768,7 +1768,7 @@ have more advantages than disadvantages:
 <li>The overloading rules are much simpler.</li>
 <li>An expression can be understood without its calling context.</li>
 <li>Errors caused by unplanned automatic type conversions cannot happen.</li>
-<li>Since you have to do type conversions explicit you are more aware of the
+<li>Since you have to do type conversions explicitly you are more aware of the
     run time overhead.</li>
 </ol></div>
 


### PR DESCRIPTION
This just corrects 3 typos on the FAQ page.